### PR TITLE
cache client sarco

### DIFF
--- a/apps/webapp/eaas-client/src/store/index.ts
+++ b/apps/webapp/eaas-client/src/store/index.ts
@@ -3,8 +3,10 @@ import { EmbalmActions } from "./embalm/actions";
 import { EmbalmState, embalmInitialState, embalmReducer } from "./embalm/reducer";
 import { UserActions } from "./user/actions";
 import { UserState, userInitialState, userReducer } from "./user/reducer";
+import { SarcophagiActions } from "./sarcophagi/actions";
+import { SarcophagiState, sarcophagiInitialState, sarcophagiReducer } from "./sarcophagi/reducer";
 
-export type Actions = UserActions | EmbalmActions;
+export type Actions = UserActions | EmbalmActions | SarcophagiActions;
 
 interface Context {
   state: RootState;
@@ -26,16 +28,19 @@ export function useDispatch(): React.Dispatch<Actions> {
 export interface RootState {
   userState: UserState;
   embalmState: EmbalmState;
+  sarcophagiState: SarcophagiState;
 }
 
 export const initialState: RootState = {
   userState: userInitialState,
   embalmState: embalmInitialState,
+  sarcophagiState: sarcophagiInitialState,
 };
 
 export function storeReducer(state: RootState, action: Actions): RootState {
   return {
     userState: userReducer(state.userState, action),
     embalmState: embalmReducer(state.embalmState, action),
+    sarcophagiState: sarcophagiReducer(state.sarcophagiState, action),
   };
 }

--- a/apps/webapp/eaas-client/src/store/sarcophagi/actions.ts
+++ b/apps/webapp/eaas-client/src/store/sarcophagi/actions.ts
@@ -1,0 +1,23 @@
+import { SarcophagusDataWithClientEmail } from "ui/sarcophagi/EmbalmerSarcophagi";
+import { ActionMap } from "../ActionMap";
+
+export enum ActionType {
+  SetClientSarcophagi = "SARCO_SET_CLIENT_SARCOPHAGI",
+}
+
+type SarcophagiPayload = {
+  [ActionType.SetClientSarcophagi]: { clientSarcophagi: SarcophagusDataWithClientEmail[] };
+};
+
+export function setClientSarcophagi(
+  clientSarcophagi: SarcophagusDataWithClientEmail[],
+): SarcophagiActions {
+  return {
+    type: ActionType.SetClientSarcophagi,
+    payload: {
+      clientSarcophagi,
+    },
+  };
+}
+
+export type SarcophagiActions = ActionMap<SarcophagiPayload>[keyof ActionMap<SarcophagiPayload>];

--- a/apps/webapp/eaas-client/src/store/sarcophagi/reducer.ts
+++ b/apps/webapp/eaas-client/src/store/sarcophagi/reducer.ts
@@ -1,0 +1,21 @@
+import { SarcophagusDataWithClientEmail } from "ui/sarcophagi/EmbalmerSarcophagi";
+import { Actions } from "..";
+import { ActionType } from "./actions";
+
+export interface SarcophagiState {
+  clientSarcophagi: SarcophagusDataWithClientEmail[];
+}
+
+export const sarcophagiInitialState: SarcophagiState = {
+  clientSarcophagi: [],
+};
+
+export function sarcophagiReducer(state: SarcophagiState, action: Actions): SarcophagiState {
+  switch (action.type) {
+    case ActionType.SetClientSarcophagi:
+      return { ...state, clientSarcophagi: action.payload.clientSarcophagi };
+
+    default:
+      return state;
+  }
+}

--- a/apps/webapp/eaas-client/src/ui/sarcophagi/ClientSarcophagi.tsx
+++ b/apps/webapp/eaas-client/src/ui/sarcophagi/ClientSarcophagi.tsx
@@ -4,21 +4,25 @@ import { NoSarcpohagi } from "./components/NoSarcophagi";
 import { SarcoTable } from "./components/SarcoTable";
 import { getClientSarcophagi } from "api/sarcophagi";
 import { getClientSarcophagiFailed } from "utils/toast";
-import { SarcophagusDataWithClientEmail } from "./EmbalmerSarcophagi";
+import { useDispatch, useSelector } from "store";
+import { setClientSarcophagi } from "store/sarcophagi/actions";
 
 export function ClientSarcophagi() {
   const [isLoadingSarcophagi, setIsLoadingSarcophagi] = useState(false);
   const [loadedSarcophagi, setLoadedSarcophagi] = useState(false);
-  const [clientSarcophagi, setClientSarcophagi] = useState<SarcophagusDataWithClientEmail[]>([]);
+
   const toast = useToast();
+
+  const dispatch = useDispatch();
+  const { clientSarcophagi } = useSelector((state) => state.sarcophagiState);
 
   useEffect(() => {
     if (!loadedSarcophagi) {
       setIsLoadingSarcophagi(true);
-
+      
       getClientSarcophagi()
         .then((res) => {
-          setClientSarcophagi(res);
+          dispatch(setClientSarcophagi(res));
           setIsLoadingSarcophagi(false);
           setLoadedSarcophagi(true);
         })
@@ -27,10 +31,10 @@ export function ClientSarcophagi() {
           setIsLoadingSarcophagi(false);
         });
     }
-  }, [loadedSarcophagi, toast]);
+  }, [dispatch, loadedSarcophagi, toast]);
 
   function sarcophagiPanel() {
-    if (isLoadingSarcophagi) {
+    if (clientSarcophagi.length === 0 && isLoadingSarcophagi) {
       return (
         <Center my={16}>
           <Spinner size="xl" />
@@ -38,7 +42,7 @@ export function ClientSarcophagi() {
       );
     }
 
-    if (!isLoadingSarcophagi && clientSarcophagi?.length === 0) {
+    if (!isLoadingSarcophagi && clientSarcophagi.length === 0) {
       return <NoSarcpohagi />;
     }
 


### PR DESCRIPTION
This PR uses the Redux store to store client sarcophagi. 

It is still being refetched every time the component is loaded, only now that there exist stored sarco after an initial fetch, the loader is not shown and so it doesn't seem "slow". Refreshing the page will clear this state as I'm not using local storage, which I think is fine for now.

I have thought about fine tuning the refetch frequency, maybe adding an explicit reload button, but have elected to focus on other pending tasks for now.

Embalmer sarcophagi are not in the store as the UI is all on one page and the only way atm to "navigate away" from the table is to refresh the page. For now that suffices.